### PR TITLE
specific failure type for invalid strings

### DIFF
--- a/lib/URLcrypt.rb
+++ b/lib/URLcrypt.rb
@@ -54,10 +54,11 @@ module URLcrypt
   end
   
   def self.decrypt(data)
-    parts = data.split('Z').map{|part| decode(part)}
+    iv, encrypted = data.split('Z').map{|part| decode(part)}
+    fail DecryptError, "not a valid string to decrypt" unless iv && encrypted
     decrypter = cipher(:decrypt)
-    decrypter.iv = parts[0]
-    decrypter.update(parts[1]) + decrypter.final 
+    decrypter.iv = iv
+    decrypter.update(encrypted) + decrypter.final 
   end
     
   def self.encrypt(data)
@@ -75,4 +76,5 @@ module URLcrypt
       cipher
     end
 
+  class DecryptError < ::ArgumentError; end
 end

--- a/test/URLcrypt_test.rb
+++ b/test/URLcrypt_test.rb
@@ -64,4 +64,10 @@ class TestURLcrypt < Test::Unit::TestCase
     assert_equal(URLcrypt::decrypt(encrypted), original)
   end
 
+  def test_decrypt_error
+    error = assert_raises(URLcrypt::DecryptError) do
+      ::URLcrypt::decrypt("just some plaintext")
+    end
+    assert_equal error.message, "not a valid string to decrypt"
+  end
 end


### PR DESCRIPTION
### Objective
Fail in a specific way when the "encrypted string" is not valid.

### Why Do I Care?
I have a case where I was receiving a bunch of requests to an unsubscribe link that tried to decrypt a token, but the token was forged so that the decrypting step failed with an error message like:

```
TypeError: can't convert nil into String
```

That message was being thrown from `Cipher.java` (JRuby's OpenSSL implementation) because we were trying to decrypt a nil value. I would like to specifically catch the failure and respond appropriately from my Rails app, but  I don't just want to catch the coercion error in general.

### How Did I Implement It?
This PR adds a specific check during decryption and creates a specific error type that I can catch. Also while I was there I decided to change the variable name `parts` into `iv` and `encrypted` rather than using `parts[0]` and `parts[1]`. I thought those names were a bit more readable.